### PR TITLE
Add QuerySpec CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ waro --output table sales list --fields id,status,totalAmount --limit 10
 # Stable machine-readable output for agents
 waro --output agent-json customers list --limit 20 --fields customer_id,name,total_spent
 waro --output agent-json financial products --fields products,metrics
+waro --output agent-json queries schema
+waro --output agent-json queries run --spec '{"dataset":"sales_items","measures":["revenue"],"dimensions":["product"],"order_by":[{"field":"revenue","direction":"desc"}],"limit":5}'
 
 # Inspect endpoint schema (useful for AI agents — no API key needed)
 waro schema
@@ -84,6 +86,8 @@ waro schema customers list | jq '.capabilities'
 waro schema analytics food-cost | jq '.capabilities.semantic_aliases'
 waro schema analytics rfm | jq '.capabilities'
 waro schema analytics churn-risk | jq '.capabilities'
+waro schema queries schema
+waro schema queries run
 waro schema sales detail | jq '.params[] | select(.required == true)'
 
 # Auto-paginate (NDJSON output, one object per line)

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use anyhow::Result;
-use reqwest::Client;
+use reqwest::{Client, Response};
 use serde_json::Value;
 
 pub struct WaroClient {
@@ -37,6 +37,30 @@ impl WaroClient {
                 }
             })?;
 
+        self.handle_response(resp).await
+    }
+
+    pub async fn get(&self, path: &str) -> Result<Value> {
+        let url = format!("{}{}", self.config.api_url, path);
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_connect() || e.is_timeout() {
+                    anyhow::anyhow!("Cannot reach {} — check WARO_API_URL", self.config.api_url)
+                } else {
+                    anyhow::anyhow!("Network error: {}", e)
+                }
+            })?;
+
+        self.handle_response(resp).await
+    }
+
+    async fn handle_response(&self, resp: Response) -> Result<Value> {
         let status = resp.status();
         let json: Value = resp.json().await?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod analytics;
 pub mod customers;
 pub mod financial;
 pub mod menu;
+pub mod queries;
 pub mod sales;
 pub mod schema;
 pub mod waros;

--- a/src/commands/queries.rs
+++ b/src/commands/queries.rs
@@ -1,0 +1,155 @@
+use crate::client::WaroClient;
+use crate::output;
+use crate::spinner::Spinner;
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+pub struct QueriesArgs {
+    #[command(subcommand)]
+    pub command: QueriesCommands,
+}
+
+#[derive(Subcommand)]
+pub enum QueriesCommands {
+    /// Fetch available safe QuerySpec datasets and fields
+    Schema,
+    /// Run a safe QuerySpec against the API
+    Run(RunArgs),
+}
+
+impl QueriesArgs {
+    pub fn command_label(&self) -> &'static str {
+        match self.command {
+            QueriesCommands::Schema => "queries schema",
+            QueriesCommands::Run(_) => "queries run",
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct RunArgs {
+    /// QuerySpec JSON string or path to a JSON file
+    #[arg(long)]
+    spec: String,
+
+    /// Validate and print request locally without calling the API
+    #[arg(long)]
+    dry_run: bool,
+}
+
+pub async fn run(
+    args: QueriesArgs,
+    client: &WaroClient,
+    format: &str,
+    fields: Option<String>,
+) -> Result<()> {
+    match args.command {
+        QueriesCommands::Schema => schema(client, format, fields).await,
+        QueriesCommands::Run(a) => run_query(a, client, format, fields).await,
+    }
+}
+
+async fn schema(client: &WaroClient, format: &str, fields: Option<String>) -> Result<()> {
+    let sp = Spinner::start();
+    let resp = client.get("/v1/queries/schema").await?;
+    sp.stop();
+    output::emit("queries schema", resp, format, fields.as_deref())?;
+    Ok(())
+}
+
+async fn run_query(
+    a: RunArgs,
+    client: &WaroClient,
+    format: &str,
+    fields: Option<String>,
+) -> Result<()> {
+    let spec = parse_queryspec(&a.spec)?;
+
+    if a.dry_run {
+        println!("DRY RUN - POST /v1/queries/run");
+        println!("{}", serde_json::to_string_pretty(&spec)?);
+        return Ok(());
+    }
+
+    let sp = Spinner::start();
+    let resp = client.post("/v1/queries/run", spec).await?;
+    sp.stop();
+    output::emit("queries run", resp, format, fields.as_deref())?;
+    Ok(())
+}
+
+fn parse_queryspec(spec: &str) -> Result<Value> {
+    let raw = if Path::new(spec).is_file() {
+        std::fs::read_to_string(spec)
+            .with_context(|| format!("Invalid QuerySpec file: cannot read {spec}"))?
+    } else {
+        spec.to_string()
+    };
+
+    let value: Value =
+        serde_json::from_str(&raw).with_context(|| "Invalid QuerySpec JSON".to_string())?;
+    let Some(obj) = value.as_object() else {
+        bail!("Invalid QuerySpec: spec must be a JSON object");
+    };
+    match obj.get("dataset").and_then(Value::as_str) {
+        Some(dataset) if !dataset.trim().is_empty() => Ok(value),
+        _ => bail!("Invalid QuerySpec: dataset is required"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_queryspec;
+    use serde_json::json;
+
+    #[test]
+    fn parse_queryspec_accepts_json_string() {
+        let value = parse_queryspec(
+            r#"{"dataset":"sales_items","measures":["revenue"],"dimensions":["product"],"limit":5}"#,
+        )
+        .unwrap();
+
+        assert_eq!(value["dataset"], "sales_items");
+    }
+
+    #[test]
+    fn parse_queryspec_accepts_file_path() {
+        let path = std::env::temp_dir().join("waro_queryspec_test.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string(&json!({
+                "dataset": "customers",
+                "measures": ["total_spent"],
+                "dimensions": ["customer"],
+                "limit": 5
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let value = parse_queryspec(path.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(value["dataset"], "customers");
+    }
+
+    #[test]
+    fn parse_queryspec_rejects_malformed_json() {
+        let err = parse_queryspec("{bad-json").unwrap_err().to_string();
+
+        assert!(err.contains("Invalid QuerySpec JSON"));
+    }
+
+    #[test]
+    fn parse_queryspec_requires_dataset() {
+        let err = parse_queryspec(r#"{"measures":["revenue"]}"#)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("dataset is required"));
+    }
+}

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -6,7 +6,7 @@ use crate::contract;
 
 #[derive(Args)]
 pub struct SchemaArgs {
-    /// Command group: sales | customers | menu | analytics | financial | waros (omit to list all)
+    /// Command group: sales | customers | menu | analytics | financial | waros | queries (omit to list all)
     group: Option<String>,
 
     /// Subcommand: list | metrics | detail | products | recipes | modifiers |
@@ -50,7 +50,8 @@ fn valid_commands() -> &'static str {
      analytics menu, analytics food-cost, analytics alerts, analytics data-quality, \
      analytics cohort, analytics waros, analytics rfm, analytics churn-risk, \
      financial products, \
-     waros estimate, waros balances, waros customer"
+     waros estimate, waros balances, waros customer, \
+     queries schema, queries run"
 }
 
 fn all_schemas() -> Value {
@@ -77,6 +78,8 @@ fn all_schemas() -> Value {
         schema_for("waros", "estimate").unwrap(),
         schema_for("waros", "balances").unwrap(),
         schema_for("waros", "customer").unwrap(),
+        schema_for("queries", "schema").unwrap(),
+        schema_for("queries", "run").unwrap(),
     ])
 }
 
@@ -99,6 +102,25 @@ fn schema_for(group: &str, subcommand: &str) -> Option<Value> {
                 { "name": "timezone",       "type": "string",  "default": "America/Bogota", "required": false, "description": "IANA timezone" },
                 { "name": "sort-field",     "type": "string",  "default": "order_date",     "required": false, "description": "Field to sort by" },
                 { "name": "sort-direction", "type": "string",  "default": "desc",           "required": false, "description": "Sort direction: asc | desc" }
+            ]
+        })),
+        ("queries", "schema") => Some(json!({
+            "command": "queries schema",
+            "method": "GET",
+            "path": "/v1/queries/schema",
+            "scope": "read",
+            "paginates": false,
+            "params": []
+        })),
+        ("queries", "run") => Some(json!({
+            "command": "queries run",
+            "method": "POST",
+            "path": "/v1/queries/run",
+            "scope": "dataset_scope",
+            "paginates": false,
+            "params": [
+                { "name": "spec", "type": "json|string", "default": null, "required": true, "description": "QuerySpec JSON string or path to a JSON file" },
+                { "name": "dry-run", "type": "boolean", "default": false, "required": false, "description": "Validate and print request locally without calling the API" }
             ]
         })),
         ("sales", "metrics") => Some(json!({

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -609,6 +609,60 @@ fn semantic_metadata_for(command: &str) -> Option<Value> {
                 "cannot_answer": ["sales_metrics"]
             }
         }),
+        "queries schema" => json!({
+            "domain": "queries",
+            "description": "Lista datasets, dimensiones, medidas, filtros y campos ordenables del contrato QuerySpec seguro.",
+            "tags": ["queries", "queryspec", "schema", "analytics"],
+            "examples": ["datasets disponibles", "campos para queryspec", "schema queries"],
+            "capabilities": {
+                "entity": "query_dataset",
+                "grain": "dataset",
+                "measures": [],
+                "dimensions": ["name", "label", "description", "required_scope", "dimensions", "measures", "filters", "sortable_fields"],
+                "supported_operations": ["discover", "list"],
+                "default_rank": ["name"],
+                "active_condition": [],
+                "supports_period": false,
+                "semantic_aliases": {
+                    "datasets": ["datasets", "tablas disponibles", "fuentes disponibles"],
+                    "measures": ["metricas", "medidas", "valores"],
+                    "dimensions": ["dimensiones", "campos", "agrupaciones"],
+                    "filters": ["filtros"],
+                    "sortable_fields": ["ordenar", "sort", "ranking"]
+                },
+                "answer_patterns": ["descubrir queryspec", "listar datasets", "ver campos disponibles"],
+                "join_keys": ["name"],
+                "cannot_answer": ["execute_query_without_run"]
+            }
+        }),
+        "queries run" => json!({
+            "domain": "queries",
+            "description": "Ejecuta un QuerySpec seguro validado por la API y devuelve filas analiticas normalizadas.",
+            "tags": ["queries", "queryspec", "analytics", "dynamic"],
+            "examples": ["productos mas vendidos con margen", "clientes por ticket promedio", "productos con utilidad baja"],
+            "capabilities": {
+                "entity": "query_row",
+                "grain": "dynamic_dataset_row",
+                "measures": ["quantity_sold", "revenue", "orders_count", "avg_price", "order_count", "total_spent", "avg_ticket", "waros_balance", "profit_per_unit", "profit_margin_pct", "profit_margin_real_pct", "profit_margin_operativo_pct", "total_profit"],
+                "dimensions": ["product", "product_id", "category", "day", "customer", "customer_id", "classification"],
+                "supported_operations": ["filter", "aggregate", "group", "rank", "sort", "limit", "compare"],
+                "default_rank": ["revenue", "quantity_sold", "total_profit", "total_spent"],
+                "active_condition": ["limit", "dataset"],
+                "supports_period": true,
+                "semantic_aliases": {
+                    "quantity_sold": ["unidades vendidas", "cantidad vendida", "volumen"],
+                    "revenue": ["ventas", "ingresos", "facturacion"],
+                    "total_profit": ["utilidad", "ganancia", "profit"],
+                    "profit_margin_pct": ["margen", "rentabilidad"],
+                    "total_spent": ["valor comprado", "gasto cliente"],
+                    "avg_ticket": ["ticket promedio"],
+                    "classification": ["clasificacion", "estrella", "plowhorse", "puzzle", "dog"]
+                },
+                "answer_patterns": ["analisis dinamico", "ranking con metricas", "comparar dimensiones", "diagnostico queryspec"],
+                "join_keys": ["product_id", "customer_id"],
+                "cannot_answer": ["raw_sql", "write_operations", "unallowlisted_fields"]
+            }
+        }),
         _ => return None,
     };
     Some(metadata)
@@ -812,6 +866,41 @@ const FINANCIAL_PRODUCTS_FIELDS: &[&str] = &[
 const WAROS_ESTIMATE_FIELDS: &[&str] = &["earned", "total", "tier"];
 const WAROS_BALANCES_FIELDS: &[&str] = &["profile_id", "balance"];
 const WAROS_CUSTOMER_FIELDS: &[&str] = &["balance", "customer", "profile_id", "tier"];
+const QUERIES_SCHEMA_FIELDS: &[&str] = &[
+    "default_limit",
+    "description",
+    "dimensions",
+    "filters",
+    "label",
+    "max_limit",
+    "measures",
+    "name",
+    "required_scope",
+    "sortable_fields",
+];
+const QUERIES_RUN_FIELDS: &[&str] = &[
+    "avg_price",
+    "avg_ticket",
+    "category",
+    "classification",
+    "customer",
+    "customer_id",
+    "day",
+    "last_order_date",
+    "order_count",
+    "orders_count",
+    "product",
+    "product_id",
+    "profit_margin_operativo_pct",
+    "profit_margin_pct",
+    "profit_margin_real_pct",
+    "profit_per_unit",
+    "quantity_sold",
+    "revenue",
+    "total_profit",
+    "total_spent",
+    "waros_balance",
+];
 
 const DATA_WRAPPER_KEYS: &[&str] = &["data", "meta", "pagination", "success"];
 const DATA_META_SUCCESS_KEYS: &[&str] = &["data", "meta", "success"];
@@ -831,6 +920,7 @@ const ANALYTICS_CHURN_RISK_KEYS: &[&str] = &[
     "total_count",
 ];
 const WAROS_BALANCES_KEYS: &[&str] = &["balances"];
+const QUERIES_TOP_LEVEL_KEYS: &[&str] = &["data", "success"];
 
 pub const CONTRACTS: &[CommandContract] = &[
     CommandContract {
@@ -1096,6 +1186,30 @@ pub const CONTRACTS: &[CommandContract] = &[
         fields: WAROS_CUSTOMER_FIELDS,
         default_fields: WAROS_CUSTOMER_FIELDS,
         top_level_keys: WAROS_CUSTOMER_FIELDS,
+    },
+    CommandContract {
+        command: "queries schema",
+        method: "GET",
+        path: "/v1/queries/schema",
+        scope: "read",
+        paginates: false,
+        shape: ResponseShape::NestedRows,
+        row_path: "data.datasets",
+        fields: QUERIES_SCHEMA_FIELDS,
+        default_fields: QUERIES_TOP_LEVEL_KEYS,
+        top_level_keys: QUERIES_TOP_LEVEL_KEYS,
+    },
+    CommandContract {
+        command: "queries run",
+        method: "POST",
+        path: "/v1/queries/run",
+        scope: "dataset_scope",
+        paginates: false,
+        shape: ResponseShape::NestedRows,
+        row_path: "data.rows",
+        fields: QUERIES_RUN_FIELDS,
+        default_fields: QUERIES_TOP_LEVEL_KEYS,
+        top_level_keys: QUERIES_TOP_LEVEL_KEYS,
     },
 ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ enum Commands {
     Financial(commands::financial::FinancialArgs),
     /// WaRo loyalty commands (estimate, balances, customer wallet)
     Waros(commands::waros::WarosArgs),
+    /// Safe analytical QuerySpec commands
+    Queries(commands::queries::QueriesArgs),
     /// Print current config (API URL, key prefix)
     Config,
     /// Generate shell completion script
@@ -122,8 +124,14 @@ fn error_kind(message: &str) -> &'static str {
         "validation"
     } else if message.contains("HTTP")
         || message.contains("API")
+        || message.contains("Cannot reach")
+        || message.contains("Network error")
         || message.contains("request")
         || message.contains("response")
+        || message.contains("Resource not found")
+        || message.contains("Insufficient scope")
+        || message.contains("Rate limit")
+        || message.contains("Server error")
     {
         "api"
     } else {
@@ -139,6 +147,7 @@ fn command_label(command: &Commands) -> String {
         Commands::Analytics(args) => args.command_label().to_string(),
         Commands::Financial(args) => args.command_label().to_string(),
         Commands::Waros(args) => args.command_label().to_string(),
+        Commands::Queries(args) => args.command_label().to_string(),
         Commands::Config => "config".to_string(),
         Commands::Completions { .. } => "completions".to_string(),
         Commands::Schema(_) => "schema".to_string(),
@@ -178,6 +187,9 @@ async fn run(cli: Cli) -> Result<()> {
             commands::financial::run(args, &client, &out_format, fields).await?
         }
         Commands::Waros(args) => commands::waros::run(args, &client, &out_format, fields).await?,
+        Commands::Queries(args) => {
+            commands::queries::run(args, &client, &out_format, fields).await?
+        }
         Commands::Config => {
             client.print_config();
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -76,6 +76,8 @@ fn contract_registry_covers_schema_commands() {
         "waros estimate",
         "waros balances",
         "waros customer",
+        "queries schema",
+        "queries run",
     ];
 
     for command in commands {
@@ -244,6 +246,22 @@ fn rows_for_contract_extracts_supported_shapes() {
         churn,
     );
     assert_eq!(rows[0]["risk_score"], 0.8);
+
+    let queries_schema = contract::contract_for("queries schema").unwrap();
+    assert_eq!(queries_schema.shape, ResponseShape::NestedRows);
+    let rows = rows_for_contract(
+        &json!({ "success": true, "data": { "datasets": [{ "name": "sales_items" }] } }),
+        queries_schema,
+    );
+    assert_eq!(rows[0]["name"], "sales_items");
+
+    let queries_run = contract::contract_for("queries run").unwrap();
+    assert_eq!(queries_run.shape, ResponseShape::NestedRows);
+    let rows = rows_for_contract(
+        &json!({ "success": true, "data": { "rows": [{ "product": "Burger", "revenue": 120000 }], "columns": ["product", "revenue"] } }),
+        queries_run,
+    );
+    assert_eq!(rows[0]["product"], "Burger");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `waro queries schema` and `waro queries run --spec` commands
- add QuerySpec schema/agent-json contracts and semantic metadata
- add parser/contract tests and README examples

## Tests
- `cargo fmt --check`
- `cargo test`
- `cargo run -- schema queries schema`
- `cargo run -- schema queries run`
- `cargo run -- queries run --spec ... --dry-run --output agent-json`
- malformed spec returns `agent-json` validation error

## Note
- Live `queries run` against the configured API returned structured `agent-json` API error: `Resource not found.` The CLI path works; endpoint appears unavailable in that environment.

Closes #28